### PR TITLE
add OAuth2.0 client credentials authentication

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,3 +20,12 @@ the following arguments are supported in the ORY Hydra `provider` block:
 
 * `url` - (Optional) URL for Hydra [administrative API](https://www.ory.sh/hydra/docs/reference/api/#administrative-endpoints).
 It must be provided, but it can also be sourced from the `ORY_HYDRA_URL` environment variable.
+
+### Authentication
+
+If the Hydra administrative API is protected with the OAuth2.0 "client credentials" token flow,
+the following arguments can be set to obtain a bearer token beforehand.
+
+* `oauth2_token_url` - (Optional) Token URL to use for OAuth2.0 flow. Can also be sourced from the `ORY_HYDRA_OAUTH2_TOKEN_URL` environment variable.
+* `oauth2_client_id` - (Optional) Client ID used for OAuth2.0 flow. Can also be sourced from the `ORY_HYDRA_OAUTH2_CLIENT_ID` environment variable.
+* `oauth2_client_secret` - (Optional) Client secret used for OAuth2.0 flow. Can also be sourced from the `ORY_HYDRA_OAUTH2_CLIENT_SECRET` environment variable.

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
 	github.com/ory/hydra-client-go v1.4.10
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 )


### PR DESCRIPTION
Hi!

First, many thanks for your work! :)

I would really love to use this provider, but our hydra admin API is protected by OAuth2.0.
This change adds the capability to obtain a valid token (via OAuth2.0 client credential flow) before calling the API.

What do you think about it? If you have some remarks, I would really like to hear them! 